### PR TITLE
Sharepoint Util Update

### DIFF
--- a/lib/io/util.d.ts
+++ b/lib/io/util.d.ts
@@ -1,2 +1,2 @@
-export declare function mkdirp(path: string): Promise<{}>;
+export declare function mkdirp(path: string): Promise<unknown>;
 export declare function createDirectoryIfNotExist(path: string, operation?: string): Promise<void>;

--- a/lib/project/generator.js
+++ b/lib/project/generator.js
@@ -33,7 +33,7 @@ const defaultConfig = {
     styleLibraryDrive: null,
 };
 async function createConfigFile(config) {
-    const cfg = Object.assign({}, defaultConfig, config);
+    const cfg = Object.assign(Object.assign({}, defaultConfig), config);
     const companyName = COMPANY_DIR;
     const projectName = cfg.name;
     let filePath = `${process.cwd()}`;
@@ -61,7 +61,7 @@ async function createDefaultConfigFile() {
         logger_1.log('Creating Default Config File', `Found package.json in current folder going to use 'name' as project name`);
         projectName = require(path.resolve(process.cwd(), 'package.json')).name;
     }
-    const config = Object.assign({}, defaultConfig, { name: projectName });
+    const config = Object.assign(Object.assign({}, defaultConfig), { name: projectName });
     createConfigFile(config);
 }
 exports.createDefaultConfigFile = createDefaultConfigFile;

--- a/lib/provisioning/provisioning.js
+++ b/lib/provisioning/provisioning.js
@@ -193,7 +193,7 @@ function createTransformer(config) {
         return cfg[key];
     }
     function getFilePath(fileName) {
-        return path.resolve(cfg.outputDir, fileName);
+        return cfg.outputDir + "/" + fileName;
     }
     var formatter = new xmlformatter_1.XmlFormatter({
         preferSpaces: true,

--- a/lib/provisioning/provisioning.js
+++ b/lib/provisioning/provisioning.js
@@ -193,7 +193,7 @@ function createTransformer(config) {
         return cfg[key];
     }
     function getFilePath(fileName) {
-        return ".\\\\" + OUTPUT_DIR + "\\" + fileName;
+        return ".\\" + fileName;
     }
     var formatter = new xmlformatter_1.XmlFormatter({
         preferSpaces: true,

--- a/lib/provisioning/provisioning.js
+++ b/lib/provisioning/provisioning.js
@@ -20,7 +20,7 @@ function createTransformer(config) {
     var fields = {};
     var errors = [];
     var cfg = {
-        outputDir: ".\\\\" + OUTPUT_DIR,
+        outputDir: path.resolve(process.cwd(), OUTPUT_DIR),
         templatesPaths: config.templatesPaths || [],
         srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir, SRC_DIR))
     };
@@ -193,7 +193,7 @@ function createTransformer(config) {
         return cfg[key];
     }
     function getFilePath(fileName) {
-        return cfg.outputDir + "/" + fileName;
+        return ".\\\\" + OUTPUT_DIR + "\\" + fileName;
     }
     var formatter = new xmlformatter_1.XmlFormatter({
         preferSpaces: true,

--- a/lib/provisioning/provisioning.js
+++ b/lib/provisioning/provisioning.js
@@ -20,7 +20,7 @@ function createTransformer(config) {
     var fields = {};
     var errors = [];
     var cfg = {
-        outputDir: path.resolve(process.cwd(), OUTPUT_DIR),
+        outputDir: ".\\\\" + OUTPUT_DIR,
         templatesPaths: config.templatesPaths || [],
         srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir, SRC_DIR))
     };
@@ -295,6 +295,7 @@ function createTransformer(config) {
         (site.termGroups || []).forEach((f) => {
             cleanConfig.termGroups[f.name] = f;
         });
+        // @ts-ignore
         const termSets = _(site.termGroups || []).map((e) => e.termSets).flatten().value();
         termSets.forEach((f) => {
             cleanConfig.termSets[f.name] = f;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,9 @@
 {
   "name": "sharepoint-util",
-  "version": "1.0.38",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/colors": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.1.3.tgz",
-      "integrity": "sha1-VBOwp6GxbdGL4OP9V9L+7Mgcx3Y="
-    },
     "@types/lodash": {
       "version": "4.14.85",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.85.tgz",
@@ -19,13 +14,13 @@
       "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha512-XA4vNO6GCBz8Smq0hqSRo4yRWMqr4FPQrWjhJt6nKskzly4/p87SfuJMFYGRyYb6jo2WNIQU2FDBsY5r1BibUA==",
       "requires": {
-        "@types/node": "8.0.53"
+        "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "8.0.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ=="
+      "version": "8.10.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
+      "integrity": "sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ=="
     },
     "@types/nunjucks": {
       "version": "3.0.0",
@@ -33,9 +28,9 @@
       "integrity": "sha512-Msxi0MEZbsQlqx9oscKWwe6N2d4QerzXgGEzgMop4+RNFlO0PvhGpwJHXdTLUWz6GaZEOrNUsBBDNNYwKTgMJw=="
     },
     "a-sync-waterfall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.0.tgz",
-      "integrity": "sha1-OOgxnXk3niRiiEW1O5ZyKyng5Hw="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
     "ansi-regex": {
       "version": "2.1.1",
@@ -43,23 +38,31 @@
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "anymatch": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
       "optional": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "optional": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "arr-diff": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "optional": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "optional": true
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -67,10 +70,16 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "optional": true
     },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "optional": true
+    },
     "array-unique": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "optional": true
     },
     "asap": {
@@ -78,53 +87,138 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
-      "optional": true
-    },
-    "balanced-match": {
+    "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "optional": true
     },
-    "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "optional": true
     },
-    "bootstrap": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-beta.2.tgz",
-      "integrity": "sha512-DzGtdTlKbrMoGMpz0LigKSqJ+MgtFKxA791PU/q062OlRG0HybNZcTLH7rpDAmLS66Y3esN9yzKHLLbqa5UR3w=="
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "optional": true
     },
-    "bootstrap-sass": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
-      "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
-    },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "optional": true,
       "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+      "optional": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
       }
     },
     "braces": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "optional": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "optional": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
       }
     },
     "camelcase": {
@@ -133,20 +227,46 @@
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
     },
     "chokidar": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+      "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
       "optional": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "optional": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
       }
     },
     "cliui": {
@@ -154,9 +274,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "code-point-at": {
@@ -164,15 +284,31 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "optional": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "optional": true
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "optional": true
     },
     "core-util-is": {
@@ -181,55 +317,215 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "optional": true
     },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "optional": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "expand-brackets": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "optional": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "optional": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "optional": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "optional": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "optional": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
       }
     },
     "extglob": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "optional": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "optional": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -238,191 +534,101 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "optional": true
     },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "optional": true,
       "requires": {
-        "for-in": "1.0.2"
+        "map-cache": "^0.2.2"
       }
     },
     "fsevents": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
+      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1",
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "aproba": {
           "version": "1.1.1",
           "bundled": true,
           "optional": true
         },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "optional": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
         },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
+        "brace-expansion": {
+          "version": "1.1.11",
           "bundled": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
+        "chownr": {
+          "version": "1.1.3",
           "bundled": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
           "bundled": true,
           "optional": true
         },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -430,124 +636,49 @@
           "optional": true
         },
         "detect-libc": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "optional": true
         },
-        "ecc-jsbn": {
-          "version": "0.1.1",
+        "fs-minipass": {
+          "version": "1.2.7",
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
-        },
-        "fstream": {
-          "version": "1.0.11",
           "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
+          "version": "7.1.6",
           "bundled": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -555,172 +686,122 @@
           "bundled": true,
           "optional": true
         },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
+        "iconv-lite": {
+          "version": "0.4.24",
           "bundled": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
-          "version": "2.0.3",
-          "bundled": true
+          "version": "2.0.4",
+          "bundled": true,
+          "optional": true
         },
         "ini": {
-          "version": "1.3.4",
+          "version": "1.3.5",
           "bundled": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
-        },
-        "isstream": {
-          "version": "0.1.2",
           "bundled": true,
           "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
-          "version": "2.0.0",
+          "version": "2.1.2",
           "bundled": true,
           "optional": true
         },
-        "node-pre-gyp": {
-          "version": "0.6.39",
+        "needle": {
+          "version": "2.4.0",
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "debug": "^3.2.6",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.14.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -728,27 +809,45 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
-        "npmlog": {
-          "version": "4.1.0",
+        "npm-bundled": {
+          "version": "1.1.1",
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
           "bundled": true,
           "optional": true
         },
@@ -760,8 +859,9 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -775,46 +875,33 @@
           "optional": true
         },
         "osenv": {
-          "version": "0.1.4",
+          "version": "0.1.5",
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
           "bundled": true,
           "optional": true
         },
         "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
+          "version": "2.0.1",
           "bundled": true,
           "optional": true
         },
         "rc": {
-          "version": "1.2.1",
+          "version": "1.2.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -825,60 +912,44 @@
           }
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
+          "version": "2.3.6",
           "bundled": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
-          "version": "2.6.1",
+          "version": "2.7.1",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true
+          "version": "5.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
         },
         "semver": {
-          "version": "5.3.0",
+          "version": "5.7.1",
           "bundled": true,
           "optional": true
         },
@@ -892,62 +963,30 @@
           "bundled": true,
           "optional": true
         },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "optional": true
-            }
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "~5.1.0"
           }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -956,124 +995,139 @@
           "optional": true
         },
         "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
+          "version": "4.4.13",
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.3"
           }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.0.1",
           "bundled": true,
           "optional": true
         },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "bundled": true,
+          "optional": true
         }
       }
     },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "optional": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "optional": true
     },
     "glob-parent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "optional": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "optional": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "optional": true
     },
-    "gulp-rename": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
-      "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "optional": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "optional": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
     },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -1081,27 +1135,52 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "optional": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "optional": true
     },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "optional": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "optional": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "optional": true
+        }
       }
     },
     "is-extendable": {
@@ -1111,116 +1190,155 @@
       "optional": true
     },
     "is-extglob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "optional": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^2.1.1"
       }
     },
     "is-number": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "optional": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
       }
     },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-      "optional": true
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "optional": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "optional": true
     },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "optional": true
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "optional": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "optional": true
     },
     "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "optional": true
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "micromatch": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "optional": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "optional": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "object-visit": "^1.0.0"
       }
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "optional": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
       }
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "optional": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "optional": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1230,19 +1348,42 @@
         "minimist": "0.0.8"
       }
     },
-    "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "optional": true
     },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "optional": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "optional": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1250,24 +1391,63 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nunjucks": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.0.1.tgz",
-      "integrity": "sha1-TedKPlULr2+jNwMj89HHwqhr3E0=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.0.tgz",
+      "integrity": "sha512-YS/qEQ6N7qCnUdm6EoYRBfJUdWNT0PpKbbRnogV2XyXbBm2STIP1O6yrdZHgwMVK7fIYUx7i8+yatEixnXSB1w==",
       "requires": {
-        "a-sync-waterfall": "1.0.0",
-        "asap": "2.0.6",
-        "chokidar": "1.7.0",
-        "yargs": "3.32.0"
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "chokidar": "^2.0.0",
+        "yargs": "^3.32.0"
       }
     },
-    "object.omit": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "optional": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "optional": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "optional": true,
+      "requires": {
+        "isobject": "^3.0.1"
       }
     },
     "os-locale": {
@@ -1275,20 +1455,20 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "optional": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "optional": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "optional": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1296,10 +1476,10 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "optional": true
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "optional": true
     },
     "pretty-data": {
@@ -1308,97 +1488,58 @@
       "integrity": "sha1-Vyqo6iNGdGerlLa1Jmpv2cj93XI="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "optional": true
     },
-    "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-      "optional": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "optional": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        }
-      }
-    },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "optional": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
       "optional": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
       }
     },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "optional": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "optional": true
     },
     "repeat-element": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -1406,34 +1547,235 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "optional": true
     },
-    "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "optional": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "optional": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "optional": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "optional": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "optional": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "optional": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "optional": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "optional": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "optional": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "optional": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "optional": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "optional": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "optional": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "optional": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "optional": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "optional": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "optional": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1441,8 +1783,120 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "optional": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "optional": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "optional": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "optional": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "optional": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "optional": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "optional": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "optional": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "optional": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "optional": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "optional": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "optional": true
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1460,8 +1914,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "y18n": {
@@ -1474,13 +1928,13 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
       "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
       "requires": {
-        "camelcase": "2.1.1",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "os-locale": "1.4.0",
-        "string-width": "1.0.2",
-        "window-size": "0.1.4",
-        "y18n": "3.2.1"
+        "camelcase": "^2.0.1",
+        "cliui": "^3.0.3",
+        "decamelize": "^1.1.1",
+        "os-locale": "^1.4.0",
+        "string-width": "^1.0.1",
+        "window-size": "^0.1.4",
+        "y18n": "^3.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sharepoint-util",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A utility library for SharePoint solutions",
   "main": "index.js",
   "typings": "./typings",
@@ -21,15 +21,14 @@
   "author": "Suhail Abood <suhail.abood@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "@types/colors": "^1.1.3",
     "@types/lodash": "^4.14.85",
     "@types/mkdirp": "^0.5.1",
-    "@types/node": "^8.0.53",
+    "@types/node": "^8.10.59",
     "@types/nunjucks": "^3.0.0",
     "colors": "^1.1.2",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
-    "nunjucks": "^3.0.1",
+    "nunjucks": "^3.2.0",
     "pretty-data": "^0.40.0"
   }
 }

--- a/src/project/generator.ts
+++ b/src/project/generator.ts
@@ -1,39 +1,39 @@
-import {writeFileSync,existsSync} from 'fs'; 
-import {createDirectoryIfNotExist} from '../io/util'; 
+import { writeFileSync, existsSync } from 'fs';
+import { createDirectoryIfNotExist } from '../io/util';
 import { logError, log } from '../util/logger';
-import * as path from 'path'; 
+import * as path from 'path';
 import { Dictionary } from 'lodash';
-export interface ProjectConfig{
-    spHost:string; 
-    url:string; 
-    name:string;
-    version:string; 
-    assetsDir:string; 
-    libDir:string; 
-    configDir:string; 
-    env:string;
-    srcDir:string;  
-    sassDir:string;
-    useSharePoint:boolean; 
-    sharePointVersion:'online'|'2013'|'2016'; 
-    distDir:string; 
-    distCssDir:string; 
-    distJsDir:string; 
-    provisioningDir:string; 
+export interface ProjectConfig {
+    spHost: string;
+    url: string;
+    name: string;
+    version: string;
+    assetsDir: string;
+    libDir: string;
+    configDir: string;
+    env: string;
+    srcDir: string;
+    sassDir: string;
+    useSharePoint: boolean;
+    sharePointVersion: 'online' | '2013' | '2016';
+    distDir: string;
+    distCssDir: string;
+    distJsDir: string;
+    provisioningDir: string;
     templatesDir: string;
-    masterPageTemplatesDir: string; 
-    pageLayoutTemplatesDir: string; 
-    templatesExtraConfig:Dictionary<any>;
-    deploymentDir:string; 
-    masterpageCatalogDrive?:string; 
-    siteAssetsDrive?:string; 
-    styleLibraryDrive?:string;
-    cdn:string[];
+    masterPageTemplatesDir: string;
+    pageLayoutTemplatesDir: string;
+    templatesExtraConfig: Dictionary<any>;
+    deploymentDir: string;
+    masterpageCatalogDrive?: string;
+    siteAssetsDrive?: string;
+    styleLibraryDrive?: string;
+    cdn: string[];
 }
 
 const COMPANY_DIR = '.sysdoc';
 
-const defaultConfig:ProjectConfig = {
+const defaultConfig: ProjectConfig = {
     spHost: 'http://tenant.sharepoint.com/',
     name: 'test-project',
     url: 'test-site',
@@ -44,27 +44,27 @@ const defaultConfig:ProjectConfig = {
     sassDir: './sass',
     distDir: './dist',
     deploymentDir: 'Sysdoc',
-    useSharePoint:true, 
-    sharePointVersion:'online',
+    useSharePoint: true,
+    sharePointVersion: 'online',
     distCssDir: './dist/css',
     distJsDir: './dist/js',
     provisioningDir: './deploy',
     templatesDir: './templates',
-    version:'1.0.0',
+    version: '1.0.0',
     masterPageTemplatesDir: './templates/masterpage',
     pageLayoutTemplatesDir: './templates/pagelayouts',
     templatesExtraConfig: {},
     cdn: [],
-    env:'dev',
+    env: 'dev',
     masterpageCatalogDrive: null,
     siteAssetsDrive: null,
     styleLibraryDrive: null,
 };
 
-export async function createConfigFile(config:ProjectConfig){
-    const cfg = {...defaultConfig,...config}; 
-    const companyName = COMPANY_DIR; 
-    const projectName = cfg.name; 
+export async function createConfigFile(config: ProjectConfig) {
+    const cfg = { ...defaultConfig, ...config };
+    const companyName = COMPANY_DIR;
+    const projectName = cfg.name;
     let filePath = `${process.cwd()}`;
     log('Creating Default Config File',
         `creating base config file in current folder: ${filePath}`);
@@ -86,23 +86,23 @@ export async function createConfigFile(config:ProjectConfig){
     }
 }
 
-export async function createDefaultConfigFile(){
+export async function createDefaultConfigFile() {
     var projectName = 'test-project';
-    var companyName = COMPANY_DIR; 
+    var companyName = COMPANY_DIR;
     log('Creating Default Config File', `creating default config file`);
-    if (existsSync(path.resolve(process.cwd(),'package.json'))){
-        log('Creating Default Config File', 
+    if (existsSync(path.resolve(process.cwd(), 'package.json'))) {
+        log('Creating Default Config File',
             `Found package.json in current folder going to use 'name' as project name`);
-        projectName = require(path.resolve(process.cwd(), 'package.json')).name; 
+        projectName = require(path.resolve(process.cwd(), 'package.json')).name;
     }
-    const config = {...defaultConfig,name:projectName};
-    createConfigFile(config); 
+    const config = { ...defaultConfig, name: projectName };
+    createConfigFile(config);
 }
 
-export function createProject(name:string, config?: ProjectConfig){
-    if (!config){
-        createDefaultConfigFile(); 
-    }else {
-        createConfigFile(config); 
+export function createProject(name: string, config?: ProjectConfig) {
+    if (!config) {
+        createDefaultConfigFile();
+    } else {
+        createConfigFile(config);
     }
 }

--- a/src/provisioning/provisioning.ts
+++ b/src/provisioning/provisioning.ts
@@ -2,7 +2,7 @@ import * as nunjucks from 'nunjucks';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as pretty from 'pretty-data';
-import { removeSpaces, parenthesize, capitalize, lowerize,getPowershellValue, getAttr, hasAttr, isString, hasItems, hasKeys } from '../util/filters';
+import { removeSpaces, parenthesize, capitalize, lowerize, getPowershellValue, getAttr, hasAttr, isString, hasItems, hasKeys } from '../util/filters';
 import { BuiltInContentType, FieldTypes, BuiltInFields } from '../sharepoint/builtin';
 import { XmlFormatter } from '../xml/xmlformatter';
 import { SharePointSite } from './sharepointsite';
@@ -18,10 +18,10 @@ import { List } from './List';
 import { TermGroup } from './termgroup';
 import { TermSet } from './termset';
 
-const INTERFACES_DIR = 'interfaces'; 
-const SRC_DIR = 'src'; 
-const OUTPUT_DIR = 'deploy'; 
-const TEMPLATES_DIR = 'templates'; 
+const INTERFACES_DIR = 'interfaces';
+const SRC_DIR = 'src';
+const OUTPUT_DIR = 'deploy';
+const TEMPLATES_DIR = 'templates';
 
 export interface ProvisionOptions {
     copyInterfaces?: boolean;
@@ -33,58 +33,58 @@ export interface SiteConfig {
 }
 
 export interface CleanAction {
-    name:string;
-    value:string; 
-    fn:(generator?:any)=>void;
+    name: string;
+    value: string;
+    fn: (generator?: any) => void;
 
 }
 
 export interface CleanConfig {
-    fields:Dictionary<Field>; 
-    contentTypes:Dictionary<ContentType>; 
-    lists:Dictionary<List>; 
-    termGroups:Dictionary<TermGroup>;
-    termSets:Dictionary<TermSet>; 
-    cleanActions:CleanAction[];
-    errors:string[];
+    fields: Dictionary<Field>;
+    contentTypes: Dictionary<ContentType>;
+    lists: Dictionary<List>;
+    termGroups: Dictionary<TermGroup>;
+    termSets: Dictionary<TermSet>;
+    cleanActions: CleanAction[];
+    errors: string[];
 }
 
 export interface TransformConfig {
     outputDir?: string;
-    rootDir ?: string;
-    srcDir ?: string;
-    interfacesDir?:string; 
-    templatesPaths?:string[];
-    consumeContentType?:(name:string,id:string)=>void; 
-    options?:ProvisionOptions; 
+    rootDir?: string;
+    srcDir?: string;
+    interfacesDir?: string;
+    templatesPaths?: string[];
+    consumeContentType?: (name: string, id: string) => void;
+    options?: ProvisionOptions;
 }
 
-export function createTransformer(config:TransformConfig) {
+export function createTransformer(config: TransformConfig) {
     var ctypes = {};
     var fields = {};
-    var errors:string[] = [];
+    var errors: string[] = [];
 
     var cfg: TransformConfig = {
-        outputDir: path.resolve(process.cwd(),OUTPUT_DIR),
-        templatesPaths:config.templatesPaths || [],
-        srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir,SRC_DIR)) 
+        outputDir: ".\\\\" + OUTPUT_DIR,
+        templatesPaths: config.templatesPaths || [],
+        srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir, SRC_DIR))
     };
-    var env:nunjucks.Environment = nunjucks.configure([path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR)),...(cfg.templatesPaths||[])], {
+    var env: nunjucks.Environment = nunjucks.configure([path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR)), ...(cfg.templatesPaths || [])], {
         trimBlocks: true
     });
 
-    async function setConfig({outputDir,rootDir,srcDir,interfacesDir,templatesPaths,consumeContentType}:TransformConfig){
+    async function setConfig({ outputDir, rootDir, srcDir, interfacesDir, templatesPaths, consumeContentType }: TransformConfig) {
         var cwd = process.cwd();
         var rootdir = rootDir || cwd;
         await createDirectoryIfNotExist(rootdir, 'Creating Root Directory');
-        cfg.outputDir = outputDir || path.resolve(rootdir ,'deploy');
-        await createDirectoryIfNotExist(cfg.outputDir,'Creating Output Directory'); 
+        cfg.outputDir = outputDir || path.resolve(rootdir, 'deploy');
+        await createDirectoryIfNotExist(cfg.outputDir, 'Creating Output Directory');
         cfg.srcDir = srcDir || path.resolve(rootDir || cwd, SRC_DIR);
-        await createDirectoryIfNotExist(cfg.srcDir, 'Creating Source Directory'); 
-        cfg.interfacesDir = interfacesDir || path.resolve(rootDir || cwd, path.join(SRC_DIR,INTERFACES_DIR));
-        await createDirectoryIfNotExist(cfg.interfacesDir, 'Creating Interfaces Directory'); 
-        cfg.templatesPaths = templatesPaths; 
-        env = nunjucks.configure([...(cfg.templatesPaths || []),path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR))], {
+        await createDirectoryIfNotExist(cfg.srcDir, 'Creating Source Directory');
+        cfg.interfacesDir = interfacesDir || path.resolve(rootDir || cwd, path.join(SRC_DIR, INTERFACES_DIR));
+        await createDirectoryIfNotExist(cfg.interfacesDir, 'Creating Interfaces Directory');
+        cfg.templatesPaths = templatesPaths;
+        env = nunjucks.configure([...(cfg.templatesPaths || []), path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR))], {
             trimBlocks: true
         });
         env.addGlobal('hasAttr', hasAttr);
@@ -106,25 +106,25 @@ export function createTransformer(config:TransformConfig) {
         env.addGlobal('booleanToUpper', booleanToUpper);
         env.addGlobal('getJsTypeForField', getJsTypeForField);
         env.addGlobal('log', log);
-        env.addGlobal('isString',isString); 
-        env.addGlobal('isObject',isObject); 
-        env.addGlobal('hasItems',hasItems);
+        env.addGlobal('isString', isString);
+        env.addGlobal('isObject', isObject);
+        env.addGlobal('hasItems', hasItems);
         env.addGlobal('hasKeys', hasKeys);
         env.addGlobal('validateContentType', validateContentType);
-        env.addGlobal('addError',addError);
-        env.addGlobal('getPowershellValue',getPowershellValue); 
-        if (consumeContentType){
-            env.addGlobal('writeContentType',function(name,id){
-                consumeContentType(name,id); 
+        env.addGlobal('addError', addError);
+        env.addGlobal('getPowershellValue', getPowershellValue);
+        if (consumeContentType) {
+            env.addGlobal('writeContentType', function (name, id) {
+                consumeContentType(name, id);
             })
         }
     }
-    
-    function clearErrors(){
-        errors = []; 
+
+    function clearErrors() {
+        errors = [];
     }
 
-    function addError(error){
+    function addError(error) {
         errors.push(error);
     }
 
@@ -142,8 +142,8 @@ export function createTransformer(config:TransformConfig) {
     function getFieldIdByName(name: string) {
         if (fields[name]) {
             return `${getAttr(fields[name], 'id')}`;
-        }else if (BuiltInFields[name]){
-            return BuiltInFields[name]; 
+        } else if (BuiltInFields[name]) {
+            return BuiltInFields[name];
         }
         errors.push(`ERROR no field with name ${name}`);
         return `ERROR no field with name ${name}`
@@ -171,13 +171,13 @@ export function createTransformer(config:TransformConfig) {
         });
     }
 
-    async function transform({spHost,url}:SiteConfig, site: SharePointSite) {
+    async function transform({ spHost, url }: SiteConfig, site: SharePointSite) {
         await setConfig(config);
         errors = [];
         ctypes = {};
         fields = {};
-        if (!spHost){
-            logError('Transform','spHost parameter is missing')
+        if (!spHost) {
+            logError('Transform', 'spHost parameter is missing')
             throw new Error('No spHost provided');
         }
         addFileds(site.fields);
@@ -207,7 +207,7 @@ export function createTransformer(config:TransformConfig) {
             template: site
         })));
         log('Base Interfaces', 'Creating base interfaces');
-        createBaseInterfaces(site); 
+        createBaseInterfaces(site);
         log('List Schemas', 'Creating site collection list schemas');
         createListSchemas(site);
         if (site.subsites) {
@@ -223,7 +223,7 @@ export function createTransformer(config:TransformConfig) {
             });
         }
         site.spHost = site.spHost || spHost;
-        if (!site.spHost.endsWith('/')){
+        if (!site.spHost.endsWith('/')) {
             site.spHost += '/';
         }
         site.url = site.url || url;
@@ -241,8 +241,8 @@ export function createTransformer(config:TransformConfig) {
         fs.writeFileSync(path.resolve(cfg.outputDir, `./deploy-${postfix}.ps1`), env.render('Deployment.ps1.njk', {
             template: site,
             postfix,
-            spHost:site.spHost,
-            url:site.url,
+            spHost: site.spHost,
+            url: site.url,
         }));
     }
 
@@ -267,16 +267,16 @@ export function createTransformer(config:TransformConfig) {
         ], childFields);
     }
 
-    function getFieldsForContentType(contentType:ContentType, childFields = []) {
-        if (!contentType){
-            logError('Get Fields For Content Type',`Undefined content type provided`);
+    function getFieldsForContentType(contentType: ContentType, childFields = []) {
+        if (!contentType) {
+            logError('Get Fields For Content Type', `Undefined content type provided`);
             errors.push(`Undefined content type provided`);
             throw new Error(`Content type cannot be undefined`);
         }
         var ff = [].concat(childFields, contentType.fields.map((e) => {
             if (!fields[e]) {
-                errors.push('Get Fields For Content Type'+`: Field ${e} does not exist`);
-                logError('Get Fields For Content Type',`Field ${e} does not exist`);
+                errors.push('Get Fields For Content Type' + `: Field ${e} does not exist`);
+                logError('Get Fields For Content Type', `Field ${e} does not exist`);
                 throw new Error(`Field ${e} does not exist`);
             }
             return fields[e];
@@ -291,9 +291,9 @@ export function createTransformer(config:TransformConfig) {
         }
     }
 
-    function createBaseInterfaces(site:SharePointSite){
+    function createBaseInterfaces(site: SharePointSite) {
         var fileName = `${cfg.interfacesDir}/CommonType.ts`;
-        log('Creating Base Interfaces',`Creating CommonType.ts at ${fileName}`);
+        log('Creating Base Interfaces', `Creating CommonType.ts at ${fileName}`);
         fs.writeFileSync(fileName, nunjucks.render('CommonType.ts.njk', {}));
         fileName = `${cfg.interfacesDir}/User.ts`;
         log('Creating Base Interfaces', `Creating User.ts at ${fileName}`);
@@ -305,28 +305,28 @@ export function createTransformer(config:TransformConfig) {
     }
 
     function createListSchemas(site: SharePointSite) {
-        site.lists.forEach((e:List) => {
-            
+        site.lists.forEach((e: List) => {
+
             var fileName = `${cfg.outputDir}/${site.id}-${e.title}.ts`;
             let tx = {};
             var fields: any[] = null;
             var contentTypeName = !e.contentTypes || e.contentTypes.length === 0 ? "Item" : e.contentTypes[0];
-            if (contentTypeName !== "Item" && !ctypes[contentTypeName]){
-                logError('Content type not found',`Content type ${contentTypeName} does not exist`);
+            if (contentTypeName !== "Item" && !ctypes[contentTypeName]) {
+                logError('Content type not found', `Content type ${contentTypeName} does not exist`);
                 throw new Error(`Could not find definition for content type ${contentTypeName}.`);
             }
             fields = !e.contentTypes || e.contentTypes.length === 0 ? getBuiltInContentTypeFields("Item") : getFieldsForContentType(ctypes[contentTypeName]);
             fields.forEach((e) => {
                 tx[e.name] = e.type;
             });
-            log('List Schemas',`Creating list schema for list ${e.title}`);
+            log('List Schemas', `Creating list schema for list ${e.title}`);
             fs.writeFileSync(fileName,
                 nunjucks.render('ListSchema.ts.njk', {
                     listTitle: (e.title),
                     schema: JSON.stringify(tx, null, '    ')
                 }));
             if (e['interface']) {
-                log('List Schemas',`Creating interface for list ${e.title}`)
+                log('List Schemas', `Creating interface for list ${e.title}`)
                 var interfaceFileName = `${cfg.interfacesDir}/${e['interface']}.ts`;
                 fs.writeFileSync(interfaceFileName, nunjucks.render('ListInterface.ts.njk', {
                     fields,
@@ -336,23 +336,23 @@ export function createTransformer(config:TransformConfig) {
         })
     }
 
-    function validate(site){
-        return _validate(site,{
-            lists:{},
-            contentTypes:{},
-            fields:{}, 
-            termGroups:{},
-            termSets:{},
-            errors:[],
-            cleanActions:[],
+    function validate(site) {
+        return _validate(site, {
+            lists: {},
+            contentTypes: {},
+            fields: {},
+            termGroups: {},
+            termSets: {},
+            errors: [],
+            cleanActions: [],
         });
     }
 
-    
 
-    function _validate(site,cleanConfig:CleanConfig){
-        (site.fields||[]).forEach((f)=>{
-            cleanConfig.fields[f.name] = f; 
+
+    function _validate(site, cleanConfig: CleanConfig) {
+        (site.fields || []).forEach((f) => {
+            cleanConfig.fields[f.name] = f;
         });
         (site.contentTypes || []).forEach((f) => {
             cleanConfig.contentTypes[f.name] = f;
@@ -363,17 +363,18 @@ export function createTransformer(config:TransformConfig) {
         (site.termGroups || []).forEach((f) => {
             cleanConfig.termGroups[f.name] = f;
         });
-        const termSets = _(site.termGroups || []).map((e: any) => e.termSets).flatten().value(); 
+        // @ts-ignore
+        const termSets = _(site.termGroups || []).map((e: any) => e.termSets).flatten().value();
         termSets.forEach((f) => {
             cleanConfig.termSets[f.name] = f;
         });
-        if (site.navigation){
-            if (site.navigation.global){
-                if (site.navigation.global.navType && site.navigation.global.navType.toLowerCase() === 'managed'){
-                    const tset = termSets.find((e)=>{
+        if (site.navigation) {
+            if (site.navigation.global) {
+                if (site.navigation.global.navType && site.navigation.global.navType.toLowerCase() === 'managed') {
+                    const tset = termSets.find((e) => {
                         return e.id === site.navigation.global.termSetId
                     });
-                    if (!tset){
+                    if (!tset) {
                         logError('Validation',
                             `Site global navigation is using a term set that does not exist ${site.navigation.global.termSetId}`)
                         cleanConfig.errors.push(`Site global navigation is using a term set that does not exist ${site.navigation.global.termSetId}`);
@@ -401,16 +402,16 @@ export function createTransformer(config:TransformConfig) {
                 }
             })
         }
-        (site.fields || []).forEach((field)=>{
+        (site.fields || []).forEach((field) => {
             if (field.type && (field.type.toLowerCase().indexOf('lookup') !== -1)) {
                 if (field.listTitle) {
                     if (!cleanConfig.lists[field.listTitle]) {
                         cleanConfig.cleanActions.push({
                             name: `Delete this field ${field.name}`,
-                            value:`delete.${site.url}.${field.id}`, 
+                            value: `delete.${site.url}.${field.id}`,
                             fn: () => {
-                                site.fields = site.fields.filter((e)=>{
-                                    return e.name !== field.name; 
+                                site.fields = site.fields.filter((e) => {
+                                    return e.name !== field.name;
                                 });
                             }
                         });
@@ -432,59 +433,59 @@ export function createTransformer(config:TransformConfig) {
                 }
             } else if (field.type && (field.type.toLowerCase().indexOf('taxonomy') !== -1)) {
                 if (field.termGroupName) {
-                    if (!cleanConfig.termGroups[field.termGroupName]){
+                    if (!cleanConfig.termGroups[field.termGroupName]) {
                         cleanConfig.cleanActions.push({
                             name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                             fn: () => {
                                 var termGroup = {
-                                    name:field.termGroupName,
-                                    termSets:[]
-                                }; 
-                                if (field.termSetName){
+                                    name: field.termGroupName,
+                                    termSets: []
+                                };
+                                if (field.termSetName) {
                                     termGroup.termSets.push({
-                                        id:generateGuid(), 
-                                        name:field.termSetName
+                                        id: generateGuid(),
+                                        name: field.termSetName
                                     });
                                 }
                                 site.termGroups.push({
-                                    name:field.termGroupName, 
+                                    name: field.termGroupName,
                                 });
                             },
                             value: `createTermGroup.${site.url}.${field.id}`,
                         });
-                        logError('Validation',`Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`);
+                        logError('Validation', `Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`);
                         errors.push(`Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`)
-                    }else {
-                        var termGroup = cleanConfig.termGroups[field.termGroupName]; 
-                        if(termGroup.termSets && termGroup.termSets.length){
-                            var tset = termGroup.termSets.find((e)=>{
-                                return e.name === field.termSetName; 
+                    } else {
+                        var termGroup = cleanConfig.termGroups[field.termGroupName];
+                        if (termGroup.termSets && termGroup.termSets.length) {
+                            var tset = termGroup.termSets.find((e) => {
+                                return e.name === field.termSetName;
                             });
                             cleanConfig.cleanActions.push({
-                                name:`Remove field ${field.name}`, 
-                                fn:()=>{
-                                    site.fields = site.fields.filter((e)=>{
-                                        return e.name !== field.name; 
-                                    }); 
+                                name: `Remove field ${field.name}`,
+                                fn: () => {
+                                    site.fields = site.fields.filter((e) => {
+                                        return e.name !== field.name;
+                                    });
                                 },
                                 value: `delete.${site.url}.${field.id}`,
-                            }); 
-                            if (!tset){
+                            });
+                            if (!tset) {
                                 cleanConfig.cleanActions.push({
                                     name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                                     fn: () => {
                                         termGroup.termSets.push({
-                                            name:field.termSetName,
+                                            name: field.termSetName,
                                             id: generateGuid(),
                                         });
                                     },
                                     value: `createTermSet.${site.url}.${field.id}`,
                                 });
                                 logError('Validation',
-                                `Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
+                                    `Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
                                 cleanConfig.errors.push(`Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
                             }
-                        }else {
+                        } else {
                             cleanConfig.cleanActions.push({
                                 name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                                 fn: () => {
@@ -499,23 +500,23 @@ export function createTransformer(config:TransformConfig) {
                                 `Taxonomy field ${field.name} refers to a term set ${field.termSetName} in a term group ${field.termGroupName} that has no term sets`);
                         }
                     }
-                }else {
-                    logError('Validation',`Taxonomy field ${field.name} is missing a 'termGroupName' attribute.`);
+                } else {
+                    logError('Validation', `Taxonomy field ${field.name} is missing a 'termGroupName' attribute.`);
                 }
-                if (!field.termSetName){
+                if (!field.termSetName) {
                     logError('Validation', `Taxonomy field ${field.name} is missing a 'termSetName' attribute.`);
                 }
             }
-        }); 
+        });
         (site.contentTypes || []).forEach((contentType) => {
             (contentType.fields || []).forEach((f) => {
                 if (!cleanConfig.fields[f]) {
                     cleanConfig.cleanActions.push({
                         name: `Remove field ${f} from content type ${contentType.name}`,
-                        value:`remove.field.${f}.contentType.${site.url}.${contentType.id}`,
-                        fn:()=>{
-                            contentType.fields = contentType.fields.filter((e)=>{
-                                return e !== f; 
+                        value: `remove.field.${f}.contentType.${site.url}.${contentType.id}`,
+                        fn: () => {
+                            contentType.fields = contentType.fields.filter((e) => {
+                                return e !== f;
                             });
                         }
                     });
@@ -524,9 +525,9 @@ export function createTransformer(config:TransformConfig) {
                         value: `create.field.${f}.contentType.${site.url}.${contentType.id}`,
                         fn: () => {
                             return {
-                                action:'addField',
-                                param:{
-                                    name:f
+                                action: 'addField',
+                                param: {
+                                    name: f
                                 }
                             };
                         }
@@ -538,17 +539,17 @@ export function createTransformer(config:TransformConfig) {
             if (contentType.parent) {
                 if (!cleanConfig.contentTypes[contentType.parent] && !BuiltInContentType[contentType.parent]) {
                     cleanConfig.cleanActions.push({
-                        name:`Create content type ${contentType.parent}`,
-                        value:`field.${contentType.name}.${contentType.parent}`,
-                        fn:(generator)=>{
-                           return {
-                               action:'addContentType',
-                               param:{
-                                   name:contentType.parent
-                               }
-                           };
+                        name: `Create content type ${contentType.parent}`,
+                        value: `field.${contentType.name}.${contentType.parent}`,
+                        fn: (generator) => {
+                            return {
+                                action: 'addContentType',
+                                param: {
+                                    name: contentType.parent
+                                }
+                            };
                         }
-                    }); 
+                    });
                     logError('Validation', `Parent content type ${contentType.parent} for content type ${contentType.name} does not exist`);
                     errors.push(`Parent content type ${contentType.parent} for content type ${contentType.name} does not exist`)
                 }
@@ -561,9 +562,9 @@ export function createTransformer(config:TransformConfig) {
                         name: `Remove content type ${ct} from list ${e.title}`,
                         value: `contentType.${site.url}.remove.${e.title}.${ct}`,
                         fn: (generator) => {
-                            e.contentTypes = e.contentTypes.filter(e=>e !== ct); 
+                            e.contentTypes = e.contentTypes.filter(e => e !== ct);
                         }
-                    }); 
+                    });
                     cleanConfig.cleanActions.push({
                         name: `Create content type ${ct}`,
                         value: `contentType.${site.url}.create.${ct}`,
@@ -575,7 +576,7 @@ export function createTransformer(config:TransformConfig) {
                                 }
                             };
                         }
-                    }); 
+                    });
                     logError('Validation', `List ${e.title} contains a content types that does not exist ${ct}`);
                     errors.push(`List ${e.title} contains a content types that does not exist ${ct}`);
                 }
@@ -599,18 +600,18 @@ export function createTransformer(config:TransformConfig) {
     //         termGroups:{},
     //         errors:[]
     //     });
-        
+
     // }
-    
-    
+
+
     return {
         setConfig,
         transform,
         validate,
         // clean,
-        get errors(){
+        get errors() {
             return errors;
         }
     };
-    
+
 }

--- a/src/provisioning/provisioning.ts
+++ b/src/provisioning/provisioning.ts
@@ -2,7 +2,7 @@ import * as nunjucks from 'nunjucks';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as pretty from 'pretty-data';
-import { removeSpaces, parenthesize, capitalize, lowerize, getPowershellValue, getAttr, hasAttr, isString, hasItems, hasKeys } from '../util/filters';
+import { removeSpaces, parenthesize, capitalize, lowerize,getPowershellValue, getAttr, hasAttr, isString, hasItems, hasKeys } from '../util/filters';
 import { BuiltInContentType, FieldTypes, BuiltInFields } from '../sharepoint/builtin';
 import { XmlFormatter } from '../xml/xmlformatter';
 import { SharePointSite } from './sharepointsite';
@@ -18,10 +18,10 @@ import { List } from './List';
 import { TermGroup } from './termgroup';
 import { TermSet } from './termset';
 
-const INTERFACES_DIR = 'interfaces';
-const SRC_DIR = 'src';
-const OUTPUT_DIR = 'deploy';
-const TEMPLATES_DIR = 'templates';
+const INTERFACES_DIR = 'interfaces'; 
+const SRC_DIR = 'src'; 
+const OUTPUT_DIR = 'deploy'; 
+const TEMPLATES_DIR = 'templates'; 
 
 export interface ProvisionOptions {
     copyInterfaces?: boolean;
@@ -33,58 +33,58 @@ export interface SiteConfig {
 }
 
 export interface CleanAction {
-    name: string;
-    value: string;
-    fn: (generator?: any) => void;
+    name:string;
+    value:string; 
+    fn:(generator?:any)=>void;
 
 }
 
 export interface CleanConfig {
-    fields: Dictionary<Field>;
-    contentTypes: Dictionary<ContentType>;
-    lists: Dictionary<List>;
-    termGroups: Dictionary<TermGroup>;
-    termSets: Dictionary<TermSet>;
-    cleanActions: CleanAction[];
-    errors: string[];
+    fields:Dictionary<Field>; 
+    contentTypes:Dictionary<ContentType>; 
+    lists:Dictionary<List>; 
+    termGroups:Dictionary<TermGroup>;
+    termSets:Dictionary<TermSet>; 
+    cleanActions:CleanAction[];
+    errors:string[];
 }
 
 export interface TransformConfig {
     outputDir?: string;
-    rootDir?: string;
-    srcDir?: string;
-    interfacesDir?: string;
-    templatesPaths?: string[];
-    consumeContentType?: (name: string, id: string) => void;
-    options?: ProvisionOptions;
+    rootDir ?: string;
+    srcDir ?: string;
+    interfacesDir?:string; 
+    templatesPaths?:string[];
+    consumeContentType?:(name:string,id:string)=>void; 
+    options?:ProvisionOptions; 
 }
 
-export function createTransformer(config: TransformConfig) {
+export function createTransformer(config:TransformConfig) {
     var ctypes = {};
     var fields = {};
-    var errors: string[] = [];
+    var errors:string[] = [];
 
     var cfg: TransformConfig = {
-        outputDir: ".\\\\" + OUTPUT_DIR,
-        templatesPaths: config.templatesPaths || [],
-        srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir, SRC_DIR))
+        outputDir: path.resolve(process.cwd(),OUTPUT_DIR),
+        templatesPaths:config.templatesPaths || [],
+        srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir,SRC_DIR)) 
     };
-    var env: nunjucks.Environment = nunjucks.configure([path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR)), ...(cfg.templatesPaths || [])], {
+    var env:nunjucks.Environment = nunjucks.configure([path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR)),...(cfg.templatesPaths||[])], {
         trimBlocks: true
     });
 
-    async function setConfig({ outputDir, rootDir, srcDir, interfacesDir, templatesPaths, consumeContentType }: TransformConfig) {
+    async function setConfig({outputDir,rootDir,srcDir,interfacesDir,templatesPaths,consumeContentType}:TransformConfig){
         var cwd = process.cwd();
         var rootdir = rootDir || cwd;
         await createDirectoryIfNotExist(rootdir, 'Creating Root Directory');
-        cfg.outputDir = outputDir || path.resolve(rootdir, 'deploy');
-        await createDirectoryIfNotExist(cfg.outputDir, 'Creating Output Directory');
+        cfg.outputDir = outputDir || path.resolve(rootdir ,'deploy');
+        await createDirectoryIfNotExist(cfg.outputDir,'Creating Output Directory'); 
         cfg.srcDir = srcDir || path.resolve(rootDir || cwd, SRC_DIR);
-        await createDirectoryIfNotExist(cfg.srcDir, 'Creating Source Directory');
-        cfg.interfacesDir = interfacesDir || path.resolve(rootDir || cwd, path.join(SRC_DIR, INTERFACES_DIR));
-        await createDirectoryIfNotExist(cfg.interfacesDir, 'Creating Interfaces Directory');
-        cfg.templatesPaths = templatesPaths;
-        env = nunjucks.configure([...(cfg.templatesPaths || []), path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR))], {
+        await createDirectoryIfNotExist(cfg.srcDir, 'Creating Source Directory'); 
+        cfg.interfacesDir = interfacesDir || path.resolve(rootDir || cwd, path.join(SRC_DIR,INTERFACES_DIR));
+        await createDirectoryIfNotExist(cfg.interfacesDir, 'Creating Interfaces Directory'); 
+        cfg.templatesPaths = templatesPaths; 
+        env = nunjucks.configure([...(cfg.templatesPaths || []),path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR))], {
             trimBlocks: true
         });
         env.addGlobal('hasAttr', hasAttr);
@@ -106,25 +106,25 @@ export function createTransformer(config: TransformConfig) {
         env.addGlobal('booleanToUpper', booleanToUpper);
         env.addGlobal('getJsTypeForField', getJsTypeForField);
         env.addGlobal('log', log);
-        env.addGlobal('isString', isString);
-        env.addGlobal('isObject', isObject);
-        env.addGlobal('hasItems', hasItems);
+        env.addGlobal('isString',isString); 
+        env.addGlobal('isObject',isObject); 
+        env.addGlobal('hasItems',hasItems);
         env.addGlobal('hasKeys', hasKeys);
         env.addGlobal('validateContentType', validateContentType);
-        env.addGlobal('addError', addError);
-        env.addGlobal('getPowershellValue', getPowershellValue);
-        if (consumeContentType) {
-            env.addGlobal('writeContentType', function (name, id) {
-                consumeContentType(name, id);
+        env.addGlobal('addError',addError);
+        env.addGlobal('getPowershellValue',getPowershellValue); 
+        if (consumeContentType){
+            env.addGlobal('writeContentType',function(name,id){
+                consumeContentType(name,id); 
             })
         }
     }
-
-    function clearErrors() {
-        errors = [];
+    
+    function clearErrors(){
+        errors = []; 
     }
 
-    function addError(error) {
+    function addError(error){
         errors.push(error);
     }
 
@@ -142,8 +142,8 @@ export function createTransformer(config: TransformConfig) {
     function getFieldIdByName(name: string) {
         if (fields[name]) {
             return `${getAttr(fields[name], 'id')}`;
-        } else if (BuiltInFields[name]) {
-            return BuiltInFields[name];
+        }else if (BuiltInFields[name]){
+            return BuiltInFields[name]; 
         }
         errors.push(`ERROR no field with name ${name}`);
         return `ERROR no field with name ${name}`
@@ -171,13 +171,13 @@ export function createTransformer(config: TransformConfig) {
         });
     }
 
-    async function transform({ spHost, url }: SiteConfig, site: SharePointSite) {
+    async function transform({spHost,url}:SiteConfig, site: SharePointSite) {
         await setConfig(config);
         errors = [];
         ctypes = {};
         fields = {};
-        if (!spHost) {
-            logError('Transform', 'spHost parameter is missing')
+        if (!spHost){
+            logError('Transform','spHost parameter is missing')
             throw new Error('No spHost provided');
         }
         addFileds(site.fields);
@@ -207,7 +207,7 @@ export function createTransformer(config: TransformConfig) {
             template: site
         })));
         log('Base Interfaces', 'Creating base interfaces');
-        createBaseInterfaces(site);
+        createBaseInterfaces(site); 
         log('List Schemas', 'Creating site collection list schemas');
         createListSchemas(site);
         if (site.subsites) {
@@ -223,7 +223,7 @@ export function createTransformer(config: TransformConfig) {
             });
         }
         site.spHost = site.spHost || spHost;
-        if (!site.spHost.endsWith('/')) {
+        if (!site.spHost.endsWith('/')){
             site.spHost += '/';
         }
         site.url = site.url || url;
@@ -241,8 +241,8 @@ export function createTransformer(config: TransformConfig) {
         fs.writeFileSync(path.resolve(cfg.outputDir, `./deploy-${postfix}.ps1`), env.render('Deployment.ps1.njk', {
             template: site,
             postfix,
-            spHost: site.spHost,
-            url: site.url,
+            spHost:site.spHost,
+            url:site.url,
         }));
     }
 
@@ -267,16 +267,16 @@ export function createTransformer(config: TransformConfig) {
         ], childFields);
     }
 
-    function getFieldsForContentType(contentType: ContentType, childFields = []) {
-        if (!contentType) {
-            logError('Get Fields For Content Type', `Undefined content type provided`);
+    function getFieldsForContentType(contentType:ContentType, childFields = []) {
+        if (!contentType){
+            logError('Get Fields For Content Type',`Undefined content type provided`);
             errors.push(`Undefined content type provided`);
             throw new Error(`Content type cannot be undefined`);
         }
         var ff = [].concat(childFields, contentType.fields.map((e) => {
             if (!fields[e]) {
-                errors.push('Get Fields For Content Type' + `: Field ${e} does not exist`);
-                logError('Get Fields For Content Type', `Field ${e} does not exist`);
+                errors.push('Get Fields For Content Type'+`: Field ${e} does not exist`);
+                logError('Get Fields For Content Type',`Field ${e} does not exist`);
                 throw new Error(`Field ${e} does not exist`);
             }
             return fields[e];
@@ -291,9 +291,9 @@ export function createTransformer(config: TransformConfig) {
         }
     }
 
-    function createBaseInterfaces(site: SharePointSite) {
+    function createBaseInterfaces(site:SharePointSite){
         var fileName = `${cfg.interfacesDir}/CommonType.ts`;
-        log('Creating Base Interfaces', `Creating CommonType.ts at ${fileName}`);
+        log('Creating Base Interfaces',`Creating CommonType.ts at ${fileName}`);
         fs.writeFileSync(fileName, nunjucks.render('CommonType.ts.njk', {}));
         fileName = `${cfg.interfacesDir}/User.ts`;
         log('Creating Base Interfaces', `Creating User.ts at ${fileName}`);
@@ -305,28 +305,28 @@ export function createTransformer(config: TransformConfig) {
     }
 
     function createListSchemas(site: SharePointSite) {
-        site.lists.forEach((e: List) => {
-
+        site.lists.forEach((e:List) => {
+            
             var fileName = `${cfg.outputDir}/${site.id}-${e.title}.ts`;
             let tx = {};
             var fields: any[] = null;
             var contentTypeName = !e.contentTypes || e.contentTypes.length === 0 ? "Item" : e.contentTypes[0];
-            if (contentTypeName !== "Item" && !ctypes[contentTypeName]) {
-                logError('Content type not found', `Content type ${contentTypeName} does not exist`);
+            if (contentTypeName !== "Item" && !ctypes[contentTypeName]){
+                logError('Content type not found',`Content type ${contentTypeName} does not exist`);
                 throw new Error(`Could not find definition for content type ${contentTypeName}.`);
             }
             fields = !e.contentTypes || e.contentTypes.length === 0 ? getBuiltInContentTypeFields("Item") : getFieldsForContentType(ctypes[contentTypeName]);
             fields.forEach((e) => {
                 tx[e.name] = e.type;
             });
-            log('List Schemas', `Creating list schema for list ${e.title}`);
+            log('List Schemas',`Creating list schema for list ${e.title}`);
             fs.writeFileSync(fileName,
                 nunjucks.render('ListSchema.ts.njk', {
                     listTitle: (e.title),
                     schema: JSON.stringify(tx, null, '    ')
                 }));
             if (e['interface']) {
-                log('List Schemas', `Creating interface for list ${e.title}`)
+                log('List Schemas',`Creating interface for list ${e.title}`)
                 var interfaceFileName = `${cfg.interfacesDir}/${e['interface']}.ts`;
                 fs.writeFileSync(interfaceFileName, nunjucks.render('ListInterface.ts.njk', {
                     fields,
@@ -336,23 +336,23 @@ export function createTransformer(config: TransformConfig) {
         })
     }
 
-    function validate(site) {
-        return _validate(site, {
-            lists: {},
-            contentTypes: {},
-            fields: {},
-            termGroups: {},
-            termSets: {},
-            errors: [],
-            cleanActions: [],
+    function validate(site){
+        return _validate(site,{
+            lists:{},
+            contentTypes:{},
+            fields:{}, 
+            termGroups:{},
+            termSets:{},
+            errors:[],
+            cleanActions:[],
         });
     }
 
+    
 
-
-    function _validate(site, cleanConfig: CleanConfig) {
-        (site.fields || []).forEach((f) => {
-            cleanConfig.fields[f.name] = f;
+    function _validate(site,cleanConfig:CleanConfig){
+        (site.fields||[]).forEach((f)=>{
+            cleanConfig.fields[f.name] = f; 
         });
         (site.contentTypes || []).forEach((f) => {
             cleanConfig.contentTypes[f.name] = f;
@@ -363,18 +363,17 @@ export function createTransformer(config: TransformConfig) {
         (site.termGroups || []).forEach((f) => {
             cleanConfig.termGroups[f.name] = f;
         });
-        // @ts-ignore
-        const termSets = _(site.termGroups || []).map((e: any) => e.termSets).flatten().value();
+        const termSets = _(site.termGroups || []).map((e: any) => e.termSets).flatten().value(); 
         termSets.forEach((f) => {
             cleanConfig.termSets[f.name] = f;
         });
-        if (site.navigation) {
-            if (site.navigation.global) {
-                if (site.navigation.global.navType && site.navigation.global.navType.toLowerCase() === 'managed') {
-                    const tset = termSets.find((e) => {
+        if (site.navigation){
+            if (site.navigation.global){
+                if (site.navigation.global.navType && site.navigation.global.navType.toLowerCase() === 'managed'){
+                    const tset = termSets.find((e)=>{
                         return e.id === site.navigation.global.termSetId
                     });
-                    if (!tset) {
+                    if (!tset){
                         logError('Validation',
                             `Site global navigation is using a term set that does not exist ${site.navigation.global.termSetId}`)
                         cleanConfig.errors.push(`Site global navigation is using a term set that does not exist ${site.navigation.global.termSetId}`);
@@ -402,16 +401,16 @@ export function createTransformer(config: TransformConfig) {
                 }
             })
         }
-        (site.fields || []).forEach((field) => {
+        (site.fields || []).forEach((field)=>{
             if (field.type && (field.type.toLowerCase().indexOf('lookup') !== -1)) {
                 if (field.listTitle) {
                     if (!cleanConfig.lists[field.listTitle]) {
                         cleanConfig.cleanActions.push({
                             name: `Delete this field ${field.name}`,
-                            value: `delete.${site.url}.${field.id}`,
+                            value:`delete.${site.url}.${field.id}`, 
                             fn: () => {
-                                site.fields = site.fields.filter((e) => {
-                                    return e.name !== field.name;
+                                site.fields = site.fields.filter((e)=>{
+                                    return e.name !== field.name; 
                                 });
                             }
                         });
@@ -433,59 +432,59 @@ export function createTransformer(config: TransformConfig) {
                 }
             } else if (field.type && (field.type.toLowerCase().indexOf('taxonomy') !== -1)) {
                 if (field.termGroupName) {
-                    if (!cleanConfig.termGroups[field.termGroupName]) {
+                    if (!cleanConfig.termGroups[field.termGroupName]){
                         cleanConfig.cleanActions.push({
                             name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                             fn: () => {
                                 var termGroup = {
-                                    name: field.termGroupName,
-                                    termSets: []
-                                };
-                                if (field.termSetName) {
+                                    name:field.termGroupName,
+                                    termSets:[]
+                                }; 
+                                if (field.termSetName){
                                     termGroup.termSets.push({
-                                        id: generateGuid(),
-                                        name: field.termSetName
+                                        id:generateGuid(), 
+                                        name:field.termSetName
                                     });
                                 }
                                 site.termGroups.push({
-                                    name: field.termGroupName,
+                                    name:field.termGroupName, 
                                 });
                             },
                             value: `createTermGroup.${site.url}.${field.id}`,
                         });
-                        logError('Validation', `Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`);
+                        logError('Validation',`Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`);
                         errors.push(`Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`)
-                    } else {
-                        var termGroup = cleanConfig.termGroups[field.termGroupName];
-                        if (termGroup.termSets && termGroup.termSets.length) {
-                            var tset = termGroup.termSets.find((e) => {
-                                return e.name === field.termSetName;
+                    }else {
+                        var termGroup = cleanConfig.termGroups[field.termGroupName]; 
+                        if(termGroup.termSets && termGroup.termSets.length){
+                            var tset = termGroup.termSets.find((e)=>{
+                                return e.name === field.termSetName; 
                             });
                             cleanConfig.cleanActions.push({
-                                name: `Remove field ${field.name}`,
-                                fn: () => {
-                                    site.fields = site.fields.filter((e) => {
-                                        return e.name !== field.name;
-                                    });
+                                name:`Remove field ${field.name}`, 
+                                fn:()=>{
+                                    site.fields = site.fields.filter((e)=>{
+                                        return e.name !== field.name; 
+                                    }); 
                                 },
                                 value: `delete.${site.url}.${field.id}`,
-                            });
-                            if (!tset) {
+                            }); 
+                            if (!tset){
                                 cleanConfig.cleanActions.push({
                                     name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                                     fn: () => {
                                         termGroup.termSets.push({
-                                            name: field.termSetName,
+                                            name:field.termSetName,
                                             id: generateGuid(),
                                         });
                                     },
                                     value: `createTermSet.${site.url}.${field.id}`,
                                 });
                                 logError('Validation',
-                                    `Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
+                                `Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
                                 cleanConfig.errors.push(`Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
                             }
-                        } else {
+                        }else {
                             cleanConfig.cleanActions.push({
                                 name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                                 fn: () => {
@@ -500,23 +499,23 @@ export function createTransformer(config: TransformConfig) {
                                 `Taxonomy field ${field.name} refers to a term set ${field.termSetName} in a term group ${field.termGroupName} that has no term sets`);
                         }
                     }
-                } else {
-                    logError('Validation', `Taxonomy field ${field.name} is missing a 'termGroupName' attribute.`);
+                }else {
+                    logError('Validation',`Taxonomy field ${field.name} is missing a 'termGroupName' attribute.`);
                 }
-                if (!field.termSetName) {
+                if (!field.termSetName){
                     logError('Validation', `Taxonomy field ${field.name} is missing a 'termSetName' attribute.`);
                 }
             }
-        });
+        }); 
         (site.contentTypes || []).forEach((contentType) => {
             (contentType.fields || []).forEach((f) => {
                 if (!cleanConfig.fields[f]) {
                     cleanConfig.cleanActions.push({
                         name: `Remove field ${f} from content type ${contentType.name}`,
-                        value: `remove.field.${f}.contentType.${site.url}.${contentType.id}`,
-                        fn: () => {
-                            contentType.fields = contentType.fields.filter((e) => {
-                                return e !== f;
+                        value:`remove.field.${f}.contentType.${site.url}.${contentType.id}`,
+                        fn:()=>{
+                            contentType.fields = contentType.fields.filter((e)=>{
+                                return e !== f; 
                             });
                         }
                     });
@@ -525,9 +524,9 @@ export function createTransformer(config: TransformConfig) {
                         value: `create.field.${f}.contentType.${site.url}.${contentType.id}`,
                         fn: () => {
                             return {
-                                action: 'addField',
-                                param: {
-                                    name: f
+                                action:'addField',
+                                param:{
+                                    name:f
                                 }
                             };
                         }
@@ -539,17 +538,17 @@ export function createTransformer(config: TransformConfig) {
             if (contentType.parent) {
                 if (!cleanConfig.contentTypes[contentType.parent] && !BuiltInContentType[contentType.parent]) {
                     cleanConfig.cleanActions.push({
-                        name: `Create content type ${contentType.parent}`,
-                        value: `field.${contentType.name}.${contentType.parent}`,
-                        fn: (generator) => {
-                            return {
-                                action: 'addContentType',
-                                param: {
-                                    name: contentType.parent
-                                }
-                            };
+                        name:`Create content type ${contentType.parent}`,
+                        value:`field.${contentType.name}.${contentType.parent}`,
+                        fn:(generator)=>{
+                           return {
+                               action:'addContentType',
+                               param:{
+                                   name:contentType.parent
+                               }
+                           };
                         }
-                    });
+                    }); 
                     logError('Validation', `Parent content type ${contentType.parent} for content type ${contentType.name} does not exist`);
                     errors.push(`Parent content type ${contentType.parent} for content type ${contentType.name} does not exist`)
                 }
@@ -562,9 +561,9 @@ export function createTransformer(config: TransformConfig) {
                         name: `Remove content type ${ct} from list ${e.title}`,
                         value: `contentType.${site.url}.remove.${e.title}.${ct}`,
                         fn: (generator) => {
-                            e.contentTypes = e.contentTypes.filter(e => e !== ct);
+                            e.contentTypes = e.contentTypes.filter(e=>e !== ct); 
                         }
-                    });
+                    }); 
                     cleanConfig.cleanActions.push({
                         name: `Create content type ${ct}`,
                         value: `contentType.${site.url}.create.${ct}`,
@@ -576,7 +575,7 @@ export function createTransformer(config: TransformConfig) {
                                 }
                             };
                         }
-                    });
+                    }); 
                     logError('Validation', `List ${e.title} contains a content types that does not exist ${ct}`);
                     errors.push(`List ${e.title} contains a content types that does not exist ${ct}`);
                 }
@@ -600,18 +599,18 @@ export function createTransformer(config: TransformConfig) {
     //         termGroups:{},
     //         errors:[]
     //     });
-
+        
     // }
-
-
+    
+    
     return {
         setConfig,
         transform,
         validate,
         // clean,
-        get errors() {
+        get errors(){
             return errors;
         }
     };
-
+    
 }

--- a/src/provisioning/provisioning.ts
+++ b/src/provisioning/provisioning.ts
@@ -2,7 +2,7 @@ import * as nunjucks from 'nunjucks';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as pretty from 'pretty-data';
-import { removeSpaces, parenthesize, capitalize, lowerize,getPowershellValue, getAttr, hasAttr, isString, hasItems, hasKeys } from '../util/filters';
+import { removeSpaces, parenthesize, capitalize, lowerize, getPowershellValue, getAttr, hasAttr, isString, hasItems, hasKeys } from '../util/filters';
 import { BuiltInContentType, FieldTypes, BuiltInFields } from '../sharepoint/builtin';
 import { XmlFormatter } from '../xml/xmlformatter';
 import { SharePointSite } from './sharepointsite';
@@ -18,10 +18,10 @@ import { List } from './List';
 import { TermGroup } from './termgroup';
 import { TermSet } from './termset';
 
-const INTERFACES_DIR = 'interfaces'; 
-const SRC_DIR = 'src'; 
-const OUTPUT_DIR = 'deploy'; 
-const TEMPLATES_DIR = 'templates'; 
+const INTERFACES_DIR = 'interfaces';
+const SRC_DIR = 'src';
+const OUTPUT_DIR = 'deploy';
+const TEMPLATES_DIR = 'templates';
 
 export interface ProvisionOptions {
     copyInterfaces?: boolean;
@@ -33,58 +33,58 @@ export interface SiteConfig {
 }
 
 export interface CleanAction {
-    name:string;
-    value:string; 
-    fn:(generator?:any)=>void;
+    name: string;
+    value: string;
+    fn: (generator?: any) => void;
 
 }
 
 export interface CleanConfig {
-    fields:Dictionary<Field>; 
-    contentTypes:Dictionary<ContentType>; 
-    lists:Dictionary<List>; 
-    termGroups:Dictionary<TermGroup>;
-    termSets:Dictionary<TermSet>; 
-    cleanActions:CleanAction[];
-    errors:string[];
+    fields: Dictionary<Field>;
+    contentTypes: Dictionary<ContentType>;
+    lists: Dictionary<List>;
+    termGroups: Dictionary<TermGroup>;
+    termSets: Dictionary<TermSet>;
+    cleanActions: CleanAction[];
+    errors: string[];
 }
 
 export interface TransformConfig {
     outputDir?: string;
-    rootDir ?: string;
-    srcDir ?: string;
-    interfacesDir?:string; 
-    templatesPaths?:string[];
-    consumeContentType?:(name:string,id:string)=>void; 
-    options?:ProvisionOptions; 
+    rootDir?: string;
+    srcDir?: string;
+    interfacesDir?: string;
+    templatesPaths?: string[];
+    consumeContentType?: (name: string, id: string) => void;
+    options?: ProvisionOptions;
 }
 
-export function createTransformer(config:TransformConfig) {
+export function createTransformer(config: TransformConfig) {
     var ctypes = {};
     var fields = {};
-    var errors:string[] = [];
+    var errors: string[] = [];
 
     var cfg: TransformConfig = {
-        outputDir: path.resolve(process.cwd(),OUTPUT_DIR),
-        templatesPaths:config.templatesPaths || [],
-        srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir,SRC_DIR)) 
+        outputDir: path.resolve(process.cwd(), OUTPUT_DIR),
+        templatesPaths: config.templatesPaths || [],
+        srcDir: config.srcDir || (config.rootDir && path.resolve(config.rootDir, SRC_DIR))
     };
-    var env:nunjucks.Environment = nunjucks.configure([path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR)),...(cfg.templatesPaths||[])], {
+    var env: nunjucks.Environment = nunjucks.configure([path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR)), ...(cfg.templatesPaths || [])], {
         trimBlocks: true
     });
 
-    async function setConfig({outputDir,rootDir,srcDir,interfacesDir,templatesPaths,consumeContentType}:TransformConfig){
+    async function setConfig({ outputDir, rootDir, srcDir, interfacesDir, templatesPaths, consumeContentType }: TransformConfig) {
         var cwd = process.cwd();
         var rootdir = rootDir || cwd;
         await createDirectoryIfNotExist(rootdir, 'Creating Root Directory');
-        cfg.outputDir = outputDir || path.resolve(rootdir ,'deploy');
-        await createDirectoryIfNotExist(cfg.outputDir,'Creating Output Directory'); 
+        cfg.outputDir = outputDir || path.resolve(rootdir, 'deploy');
+        await createDirectoryIfNotExist(cfg.outputDir, 'Creating Output Directory');
         cfg.srcDir = srcDir || path.resolve(rootDir || cwd, SRC_DIR);
-        await createDirectoryIfNotExist(cfg.srcDir, 'Creating Source Directory'); 
-        cfg.interfacesDir = interfacesDir || path.resolve(rootDir || cwd, path.join(SRC_DIR,INTERFACES_DIR));
-        await createDirectoryIfNotExist(cfg.interfacesDir, 'Creating Interfaces Directory'); 
-        cfg.templatesPaths = templatesPaths; 
-        env = nunjucks.configure([...(cfg.templatesPaths || []),path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR))], {
+        await createDirectoryIfNotExist(cfg.srcDir, 'Creating Source Directory');
+        cfg.interfacesDir = interfacesDir || path.resolve(rootDir || cwd, path.join(SRC_DIR, INTERFACES_DIR));
+        await createDirectoryIfNotExist(cfg.interfacesDir, 'Creating Interfaces Directory');
+        cfg.templatesPaths = templatesPaths;
+        env = nunjucks.configure([...(cfg.templatesPaths || []), path.resolve(__dirname, path.join('..', '..', TEMPLATES_DIR))], {
             trimBlocks: true
         });
         env.addGlobal('hasAttr', hasAttr);
@@ -106,25 +106,25 @@ export function createTransformer(config:TransformConfig) {
         env.addGlobal('booleanToUpper', booleanToUpper);
         env.addGlobal('getJsTypeForField', getJsTypeForField);
         env.addGlobal('log', log);
-        env.addGlobal('isString',isString); 
-        env.addGlobal('isObject',isObject); 
-        env.addGlobal('hasItems',hasItems);
+        env.addGlobal('isString', isString);
+        env.addGlobal('isObject', isObject);
+        env.addGlobal('hasItems', hasItems);
         env.addGlobal('hasKeys', hasKeys);
         env.addGlobal('validateContentType', validateContentType);
-        env.addGlobal('addError',addError);
-        env.addGlobal('getPowershellValue',getPowershellValue); 
-        if (consumeContentType){
-            env.addGlobal('writeContentType',function(name,id){
-                consumeContentType(name,id); 
+        env.addGlobal('addError', addError);
+        env.addGlobal('getPowershellValue', getPowershellValue);
+        if (consumeContentType) {
+            env.addGlobal('writeContentType', function (name, id) {
+                consumeContentType(name, id);
             })
         }
     }
-    
-    function clearErrors(){
-        errors = []; 
+
+    function clearErrors() {
+        errors = [];
     }
 
-    function addError(error){
+    function addError(error) {
         errors.push(error);
     }
 
@@ -142,8 +142,8 @@ export function createTransformer(config:TransformConfig) {
     function getFieldIdByName(name: string) {
         if (fields[name]) {
             return `${getAttr(fields[name], 'id')}`;
-        }else if (BuiltInFields[name]){
-            return BuiltInFields[name]; 
+        } else if (BuiltInFields[name]) {
+            return BuiltInFields[name];
         }
         errors.push(`ERROR no field with name ${name}`);
         return `ERROR no field with name ${name}`
@@ -171,13 +171,13 @@ export function createTransformer(config:TransformConfig) {
         });
     }
 
-    async function transform({spHost,url}:SiteConfig, site: SharePointSite) {
+    async function transform({ spHost, url }: SiteConfig, site: SharePointSite) {
         await setConfig(config);
         errors = [];
         ctypes = {};
         fields = {};
-        if (!spHost){
-            logError('Transform','spHost parameter is missing')
+        if (!spHost) {
+            logError('Transform', 'spHost parameter is missing')
             throw new Error('No spHost provided');
         }
         addFileds(site.fields);
@@ -207,7 +207,7 @@ export function createTransformer(config:TransformConfig) {
             template: site
         })));
         log('Base Interfaces', 'Creating base interfaces');
-        createBaseInterfaces(site); 
+        createBaseInterfaces(site);
         log('List Schemas', 'Creating site collection list schemas');
         createListSchemas(site);
         if (site.subsites) {
@@ -223,7 +223,7 @@ export function createTransformer(config:TransformConfig) {
             });
         }
         site.spHost = site.spHost || spHost;
-        if (!site.spHost.endsWith('/')){
+        if (!site.spHost.endsWith('/')) {
             site.spHost += '/';
         }
         site.url = site.url || url;
@@ -241,8 +241,8 @@ export function createTransformer(config:TransformConfig) {
         fs.writeFileSync(path.resolve(cfg.outputDir, `./deploy-${postfix}.ps1`), env.render('Deployment.ps1.njk', {
             template: site,
             postfix,
-            spHost:site.spHost,
-            url:site.url,
+            spHost: site.spHost,
+            url: site.url,
         }));
     }
 
@@ -251,7 +251,7 @@ export function createTransformer(config:TransformConfig) {
     }
 
     function getFilePath(fileName: string) {
-        return cfg.outputDir + "/" + fileName;
+        return ".\\\\" + OUTPUT_DIR + "\\" + fileName;
     }
 
     var formatter = new XmlFormatter({
@@ -267,16 +267,16 @@ export function createTransformer(config:TransformConfig) {
         ], childFields);
     }
 
-    function getFieldsForContentType(contentType:ContentType, childFields = []) {
-        if (!contentType){
-            logError('Get Fields For Content Type',`Undefined content type provided`);
+    function getFieldsForContentType(contentType: ContentType, childFields = []) {
+        if (!contentType) {
+            logError('Get Fields For Content Type', `Undefined content type provided`);
             errors.push(`Undefined content type provided`);
             throw new Error(`Content type cannot be undefined`);
         }
         var ff = [].concat(childFields, contentType.fields.map((e) => {
             if (!fields[e]) {
-                errors.push('Get Fields For Content Type'+`: Field ${e} does not exist`);
-                logError('Get Fields For Content Type',`Field ${e} does not exist`);
+                errors.push('Get Fields For Content Type' + `: Field ${e} does not exist`);
+                logError('Get Fields For Content Type', `Field ${e} does not exist`);
                 throw new Error(`Field ${e} does not exist`);
             }
             return fields[e];
@@ -291,9 +291,9 @@ export function createTransformer(config:TransformConfig) {
         }
     }
 
-    function createBaseInterfaces(site:SharePointSite){
+    function createBaseInterfaces(site: SharePointSite) {
         var fileName = `${cfg.interfacesDir}/CommonType.ts`;
-        log('Creating Base Interfaces',`Creating CommonType.ts at ${fileName}`);
+        log('Creating Base Interfaces', `Creating CommonType.ts at ${fileName}`);
         fs.writeFileSync(fileName, nunjucks.render('CommonType.ts.njk', {}));
         fileName = `${cfg.interfacesDir}/User.ts`;
         log('Creating Base Interfaces', `Creating User.ts at ${fileName}`);
@@ -305,28 +305,28 @@ export function createTransformer(config:TransformConfig) {
     }
 
     function createListSchemas(site: SharePointSite) {
-        site.lists.forEach((e:List) => {
-            
+        site.lists.forEach((e: List) => {
+
             var fileName = `${cfg.outputDir}/${site.id}-${e.title}.ts`;
             let tx = {};
             var fields: any[] = null;
             var contentTypeName = !e.contentTypes || e.contentTypes.length === 0 ? "Item" : e.contentTypes[0];
-            if (contentTypeName !== "Item" && !ctypes[contentTypeName]){
-                logError('Content type not found',`Content type ${contentTypeName} does not exist`);
+            if (contentTypeName !== "Item" && !ctypes[contentTypeName]) {
+                logError('Content type not found', `Content type ${contentTypeName} does not exist`);
                 throw new Error(`Could not find definition for content type ${contentTypeName}.`);
             }
             fields = !e.contentTypes || e.contentTypes.length === 0 ? getBuiltInContentTypeFields("Item") : getFieldsForContentType(ctypes[contentTypeName]);
             fields.forEach((e) => {
                 tx[e.name] = e.type;
             });
-            log('List Schemas',`Creating list schema for list ${e.title}`);
+            log('List Schemas', `Creating list schema for list ${e.title}`);
             fs.writeFileSync(fileName,
                 nunjucks.render('ListSchema.ts.njk', {
                     listTitle: (e.title),
                     schema: JSON.stringify(tx, null, '    ')
                 }));
             if (e['interface']) {
-                log('List Schemas',`Creating interface for list ${e.title}`)
+                log('List Schemas', `Creating interface for list ${e.title}`)
                 var interfaceFileName = `${cfg.interfacesDir}/${e['interface']}.ts`;
                 fs.writeFileSync(interfaceFileName, nunjucks.render('ListInterface.ts.njk', {
                     fields,
@@ -336,23 +336,23 @@ export function createTransformer(config:TransformConfig) {
         })
     }
 
-    function validate(site){
-        return _validate(site,{
-            lists:{},
-            contentTypes:{},
-            fields:{}, 
-            termGroups:{},
-            termSets:{},
-            errors:[],
-            cleanActions:[],
+    function validate(site) {
+        return _validate(site, {
+            lists: {},
+            contentTypes: {},
+            fields: {},
+            termGroups: {},
+            termSets: {},
+            errors: [],
+            cleanActions: [],
         });
     }
 
-    
 
-    function _validate(site,cleanConfig:CleanConfig){
-        (site.fields||[]).forEach((f)=>{
-            cleanConfig.fields[f.name] = f; 
+
+    function _validate(site, cleanConfig: CleanConfig) {
+        (site.fields || []).forEach((f) => {
+            cleanConfig.fields[f.name] = f;
         });
         (site.contentTypes || []).forEach((f) => {
             cleanConfig.contentTypes[f.name] = f;
@@ -363,17 +363,18 @@ export function createTransformer(config:TransformConfig) {
         (site.termGroups || []).forEach((f) => {
             cleanConfig.termGroups[f.name] = f;
         });
-        const termSets = _(site.termGroups || []).map((e: any) => e.termSets).flatten().value(); 
+        // @ts-ignore
+        const termSets = _(site.termGroups || []).map((e: any) => e.termSets).flatten().value();
         termSets.forEach((f) => {
             cleanConfig.termSets[f.name] = f;
         });
-        if (site.navigation){
-            if (site.navigation.global){
-                if (site.navigation.global.navType && site.navigation.global.navType.toLowerCase() === 'managed'){
-                    const tset = termSets.find((e)=>{
+        if (site.navigation) {
+            if (site.navigation.global) {
+                if (site.navigation.global.navType && site.navigation.global.navType.toLowerCase() === 'managed') {
+                    const tset = termSets.find((e) => {
                         return e.id === site.navigation.global.termSetId
                     });
-                    if (!tset){
+                    if (!tset) {
                         logError('Validation',
                             `Site global navigation is using a term set that does not exist ${site.navigation.global.termSetId}`)
                         cleanConfig.errors.push(`Site global navigation is using a term set that does not exist ${site.navigation.global.termSetId}`);
@@ -401,16 +402,16 @@ export function createTransformer(config:TransformConfig) {
                 }
             })
         }
-        (site.fields || []).forEach((field)=>{
+        (site.fields || []).forEach((field) => {
             if (field.type && (field.type.toLowerCase().indexOf('lookup') !== -1)) {
                 if (field.listTitle) {
                     if (!cleanConfig.lists[field.listTitle]) {
                         cleanConfig.cleanActions.push({
                             name: `Delete this field ${field.name}`,
-                            value:`delete.${site.url}.${field.id}`, 
+                            value: `delete.${site.url}.${field.id}`,
                             fn: () => {
-                                site.fields = site.fields.filter((e)=>{
-                                    return e.name !== field.name; 
+                                site.fields = site.fields.filter((e) => {
+                                    return e.name !== field.name;
                                 });
                             }
                         });
@@ -432,59 +433,59 @@ export function createTransformer(config:TransformConfig) {
                 }
             } else if (field.type && (field.type.toLowerCase().indexOf('taxonomy') !== -1)) {
                 if (field.termGroupName) {
-                    if (!cleanConfig.termGroups[field.termGroupName]){
+                    if (!cleanConfig.termGroups[field.termGroupName]) {
                         cleanConfig.cleanActions.push({
                             name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                             fn: () => {
                                 var termGroup = {
-                                    name:field.termGroupName,
-                                    termSets:[]
-                                }; 
-                                if (field.termSetName){
+                                    name: field.termGroupName,
+                                    termSets: []
+                                };
+                                if (field.termSetName) {
                                     termGroup.termSets.push({
-                                        id:generateGuid(), 
-                                        name:field.termSetName
+                                        id: generateGuid(),
+                                        name: field.termSetName
                                     });
                                 }
                                 site.termGroups.push({
-                                    name:field.termGroupName, 
+                                    name: field.termGroupName,
                                 });
                             },
                             value: `createTermGroup.${site.url}.${field.id}`,
                         });
-                        logError('Validation',`Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`);
+                        logError('Validation', `Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`);
                         errors.push(`Taxonomy field ${field.name} refers to a group name that does not exist ${field.termGroupName}`)
-                    }else {
-                        var termGroup = cleanConfig.termGroups[field.termGroupName]; 
-                        if(termGroup.termSets && termGroup.termSets.length){
-                            var tset = termGroup.termSets.find((e)=>{
-                                return e.name === field.termSetName; 
+                    } else {
+                        var termGroup = cleanConfig.termGroups[field.termGroupName];
+                        if (termGroup.termSets && termGroup.termSets.length) {
+                            var tset = termGroup.termSets.find((e) => {
+                                return e.name === field.termSetName;
                             });
                             cleanConfig.cleanActions.push({
-                                name:`Remove field ${field.name}`, 
-                                fn:()=>{
-                                    site.fields = site.fields.filter((e)=>{
-                                        return e.name !== field.name; 
-                                    }); 
+                                name: `Remove field ${field.name}`,
+                                fn: () => {
+                                    site.fields = site.fields.filter((e) => {
+                                        return e.name !== field.name;
+                                    });
                                 },
                                 value: `delete.${site.url}.${field.id}`,
-                            }); 
-                            if (!tset){
+                            });
+                            if (!tset) {
                                 cleanConfig.cleanActions.push({
                                     name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                                     fn: () => {
                                         termGroup.termSets.push({
-                                            name:field.termSetName,
+                                            name: field.termSetName,
                                             id: generateGuid(),
                                         });
                                     },
                                     value: `createTermSet.${site.url}.${field.id}`,
                                 });
                                 logError('Validation',
-                                `Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
+                                    `Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
                                 cleanConfig.errors.push(`Taxonomy field ${field.name} refers to a term set that does not exist in term gorup ${field.termGroupname}`);
                             }
-                        }else {
+                        } else {
                             cleanConfig.cleanActions.push({
                                 name: `Create term set ${field.termSetName} in ${field.termGroupName}`,
                                 fn: () => {
@@ -499,23 +500,23 @@ export function createTransformer(config:TransformConfig) {
                                 `Taxonomy field ${field.name} refers to a term set ${field.termSetName} in a term group ${field.termGroupName} that has no term sets`);
                         }
                     }
-                }else {
-                    logError('Validation',`Taxonomy field ${field.name} is missing a 'termGroupName' attribute.`);
+                } else {
+                    logError('Validation', `Taxonomy field ${field.name} is missing a 'termGroupName' attribute.`);
                 }
-                if (!field.termSetName){
+                if (!field.termSetName) {
                     logError('Validation', `Taxonomy field ${field.name} is missing a 'termSetName' attribute.`);
                 }
             }
-        }); 
+        });
         (site.contentTypes || []).forEach((contentType) => {
             (contentType.fields || []).forEach((f) => {
                 if (!cleanConfig.fields[f]) {
                     cleanConfig.cleanActions.push({
                         name: `Remove field ${f} from content type ${contentType.name}`,
-                        value:`remove.field.${f}.contentType.${site.url}.${contentType.id}`,
-                        fn:()=>{
-                            contentType.fields = contentType.fields.filter((e)=>{
-                                return e !== f; 
+                        value: `remove.field.${f}.contentType.${site.url}.${contentType.id}`,
+                        fn: () => {
+                            contentType.fields = contentType.fields.filter((e) => {
+                                return e !== f;
                             });
                         }
                     });
@@ -524,9 +525,9 @@ export function createTransformer(config:TransformConfig) {
                         value: `create.field.${f}.contentType.${site.url}.${contentType.id}`,
                         fn: () => {
                             return {
-                                action:'addField',
-                                param:{
-                                    name:f
+                                action: 'addField',
+                                param: {
+                                    name: f
                                 }
                             };
                         }
@@ -538,17 +539,17 @@ export function createTransformer(config:TransformConfig) {
             if (contentType.parent) {
                 if (!cleanConfig.contentTypes[contentType.parent] && !BuiltInContentType[contentType.parent]) {
                     cleanConfig.cleanActions.push({
-                        name:`Create content type ${contentType.parent}`,
-                        value:`field.${contentType.name}.${contentType.parent}`,
-                        fn:(generator)=>{
-                           return {
-                               action:'addContentType',
-                               param:{
-                                   name:contentType.parent
-                               }
-                           };
+                        name: `Create content type ${contentType.parent}`,
+                        value: `field.${contentType.name}.${contentType.parent}`,
+                        fn: (generator) => {
+                            return {
+                                action: 'addContentType',
+                                param: {
+                                    name: contentType.parent
+                                }
+                            };
                         }
-                    }); 
+                    });
                     logError('Validation', `Parent content type ${contentType.parent} for content type ${contentType.name} does not exist`);
                     errors.push(`Parent content type ${contentType.parent} for content type ${contentType.name} does not exist`)
                 }
@@ -561,9 +562,9 @@ export function createTransformer(config:TransformConfig) {
                         name: `Remove content type ${ct} from list ${e.title}`,
                         value: `contentType.${site.url}.remove.${e.title}.${ct}`,
                         fn: (generator) => {
-                            e.contentTypes = e.contentTypes.filter(e=>e !== ct); 
+                            e.contentTypes = e.contentTypes.filter(e => e !== ct);
                         }
-                    }); 
+                    });
                     cleanConfig.cleanActions.push({
                         name: `Create content type ${ct}`,
                         value: `contentType.${site.url}.create.${ct}`,
@@ -575,7 +576,7 @@ export function createTransformer(config:TransformConfig) {
                                 }
                             };
                         }
-                    }); 
+                    });
                     logError('Validation', `List ${e.title} contains a content types that does not exist ${ct}`);
                     errors.push(`List ${e.title} contains a content types that does not exist ${ct}`);
                 }
@@ -599,18 +600,18 @@ export function createTransformer(config:TransformConfig) {
     //         termGroups:{},
     //         errors:[]
     //     });
-        
+
     // }
-    
-    
+
+
     return {
         setConfig,
         transform,
         validate,
         // clean,
-        get errors(){
+        get errors() {
             return errors;
         }
     };
-    
+
 }

--- a/src/provisioning/provisioning.ts
+++ b/src/provisioning/provisioning.ts
@@ -251,7 +251,7 @@ export function createTransformer(config: TransformConfig) {
     }
 
     function getFilePath(fileName: string) {
-        return path.resolve(cfg.outputDir, fileName);
+        return cfg.outputDir + "/" + fileName;
     }
 
     var formatter = new XmlFormatter({

--- a/src/provisioning/provisioning.ts
+++ b/src/provisioning/provisioning.ts
@@ -251,7 +251,7 @@ export function createTransformer(config: TransformConfig) {
     }
 
     function getFilePath(fileName: string) {
-        return ".\\\\" + OUTPUT_DIR + "\\" + fileName;
+        return ".\\" + fileName;
     }
 
     var formatter = new XmlFormatter({

--- a/templates/Deployment.ps1.njk
+++ b/templates/Deployment.ps1.njk
@@ -21,7 +21,7 @@ Write-Log "Connecting to $siteUrl"
 
 {% endfor %}
 
-Connect-PnPOnline -Url $siteUrl
+Connect-PnPOnline -Url $siteUrl -UseWebLogin
 
 {% for command in getAttr(template,'postConnectCommands') %}
     

--- a/templates/Functions.ps1.njk
+++ b/templates/Functions.ps1.njk
@@ -123,13 +123,10 @@ function Get-WebByUrl {
         $ww = $site.OpenWeb($Url)
         $ctx.Load($ww)
         $ctx.ExecuteQuery()
-        return $ww; 
+        return $ww;
     }
     Catch
     {
-        $ww = $site.RootWeb; 
-        $ctx.Load($ww); 
-        $ctx.ExecuteQuery(); 
-        return $ww; 
+        return $null;
     }
 }

--- a/templates/Macros.html
+++ b/templates/Macros.html
@@ -1436,7 +1436,7 @@ Write-Log "Unknown Command Type {{type}}"
 
 {% macro ProvisionSubSite(s) %}
 
-$parentWeb = {% if getAttr(s,'parentWeb') == '/' or getAttr(s,'parentWeb') == 'root' or not hasAttr(s,'parentWeb') %} $rootWeb.ServerRelativeUrl {% else %} Get-WebByUrl -Url "$($rootWeb.ServerRelativeUrl)/{{getAttr(s,'parentWeb')}}" {% endif %}
+$parentWeb = {% if getAttr(s,'parentWeb') == '/' or getAttr(s,'parentWeb') == 'root' or not hasAttr(s,'parentWeb') %} $rootWeb {% else %} Get-WebByUrl -Url "$($rootWeb.ServerRelativeUrl)/{{getAttr(s,'parentWeb')}}" {% endif %}
 
 $subWebUrl = "{{getAttr(s,'url')}}"
 $fullSubWebUrl = "$($parentWeb.ServerRelativeUrl)/$($subWebUrl)";

--- a/templates/Macros.html
+++ b/templates/Macros.html
@@ -1436,15 +1436,11 @@ Write-Log "Unknown Command Type {{type}}"
 
 {% macro ProvisionSubSite(s) %}
 
-$parentWeb = {% if getAttr(s,'parentWeb') == '/' or getAttr(s,'parentWeb') == 'root' or not hasAttr(s,'parentWeb') %} $rootWeb {% else %} $null {% endif %}
+$parentWeb = {% if getAttr(s,'parentWeb') == '/' or getAttr(s,'parentWeb') == 'root' or not hasAttr(s,'parentWeb') %} $rootWeb.ServerRelativeUrl {% else %} Get-WebByUrl -Url "$($rootWeb.ServerRelativeUrl)/{{getAttr(s,'parentWeb')}}" {% endif %}
 
-if ($parentWeb -eq $null) 
-{
-    $parentWeb = Get-WebByUrl -Web $rootWeb -Url "{{getAttr(s,'parentWeb')}}" 
-}
 $subWebUrl = "{{getAttr(s,'url')}}"
-$fullSubWebUrl = "{{getAttr(s,'parentWeb')}}"+"/"+$subWebUrl;
-$subweb = Get-WebByUrl -Web $parentWeb -Url $fullSubWebUrl
+$fullSubWebUrl = "$($parentWeb.ServerRelativeUrl)/$($subWebUrl)";
+$subweb = Get-WebByUrl -Url $fullSubWebUrl
 
 if ($subweb -eq $null)
 {


### PR DESCRIPTION
Hey Suhail,

Hope you don't mind me pinging over a pull request - I've made a couple of tweaks to the Sharepoint Util package that would be useful to roll into the original (assuming you don't mind!).

Changes:

* Fixed an issue with the functions.ps1 script returning the root site Web instead of $null on error
* Made the generated deploy.ps1 file use relative paths for imports and assets - allows it to be committed if needed and also allows it to be generated on a mac and run in PowerShell on a VM
* Tidied up a number of issues around subsite deployment - mostly fixing issues for nested subsites
* Updated dependencies to close off security issues, removed unneeded @types/colors
* Added --UseWebLogin flag by default
* Various bits of linting via tslint